### PR TITLE
CNAME is missing in production

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+cdifs-49f.poker

--- a/bin/deploy
+++ b/bin/deploy
@@ -14,6 +14,7 @@ cp join_session.html $DEPLOY_ROOT/
 cp session.html $DEPLOY_ROOT/
 cp session_new.html $DEPLOY_ROOT/
 cp LICENSE $DEPLOY_ROOT/
+cp CNAME $DEPLOY_ROOT/
 cp -R dist $DEPLOY_ROOT/
 
 cd $DEPLOY_ROOT


### PR DESCRIPTION
Our cool domain is not working now since we missed CNAME file in `gh-pages` branch.