### PR TITLE
Introduce ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "airbnb-base",
+  "plugins": [
+    "import"
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,19 @@
   "extends": "airbnb-base",
   "plugins": [
     "import"
-  ]
+  ],
+  "globals": {
+    "window": true,
+    "alert": true,
+    "WebSocket": true
+  },
+  "rules": {
+    "prefer-const": 0,
+    "comma-dangle": 0,
+    "no-plusplus": 0,
+    "no-alert": 0,
+    "class-methods-use-this": 0,
+    "space-before-function-paren": [1, "never"],
+    "no-param-reassign": [2, { "props": false }]
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ branches:
     - master
 
 script:
+  - npm run eslint
   - npm run build
   - npm run deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,10 @@ branches:
 script:
   - npm run eslint
   - npm run build
-  - npm run deploy
+
+deploy:
+  provider: script
+  script: bin/deploy
+  skip_cleanup: true
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -25,17 +25,19 @@
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.18.0",
-    "bootstrap": "^3.3.7",
     "css-loader": "^0.26.1",
     "eslint": "^3.13.0",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
-    "jquery": "^3.1.1",
-    "js-cookie": "^2.1.3",
     "leancloud-storage": "^1.5.3",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
+  },
+  "dependencies": {
+    "bootstrap": "^3.3.7",
+    "jquery": "^3.1.1",
+    "js-cookie": "^2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
   },
   "scripts": {
     "start": "node_modules/.bin/webpack-dev-server --inline --hot",
-    "eslint": "eslint ./scripts",
-    "build": "node_modules/.bin/webpack",
-    "deploy": "bin/deploy"
+    "eslint": "node_modules/.bin/eslint ./scripts",
+    "build": "node_modules/.bin/webpack"
   },
   "homepage": "https://ifs49f.github.io/poker/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node_modules/.bin/webpack-dev-server --inline --hot",
+    "eslint": "eslint ./scripts",
     "build": "node_modules/.bin/webpack",
     "deploy": "bin/deploy"
   },
@@ -26,6 +27,9 @@
     "babel-preset-es2015": "^6.18.0",
     "bootstrap": "^3.3.7",
     "css-loader": "^0.26.1",
+    "eslint": "^3.13.0",
+    "eslint-config-airbnb-base": "^11.0.0",
+    "eslint-plugin-import": "^2.2.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "jquery": "^3.1.1",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -5,15 +5,15 @@ import '../styles/index.css';
 
 class App {
   constructor() {
-    $('#btn-to-join-session').click(this._handleJoinSession);
+    $('#btn-to-join-session').click(this.handleJoinSession);
   }
 
-  _handleJoinSession() {
+  handleJoinSession() {
     let sessionName = $('#input-name').val();
-    document.cookie = `session_name=${sessionName}`;
-    location.href = '/join_session.html';
+    window.document.cookie = `session_name=${sessionName}`;
+    window.location.href = '/join_session.html';
     return false;
   }
 }
 
-$(() => new App);
+$(() => new App());

--- a/scripts/join_session.js
+++ b/scripts/join_session.js
@@ -2,15 +2,15 @@ import $ from 'jquery';
 
 class Join {
   constructor() {
-    $('#btn-join-session').click(this._handleJoinSession);
+    $('#btn-join-session').click(this.handleJoinSession);
   }
 
-  _handleJoinSession() {
-    let userName = $('#input-user-name').val()
-    document.cookie = `user_name=${userName}; point=''`;
-    location.href = '/session.html';
+  handleJoinSession() {
+    let userName = $('#input-user-name').val();
+    window.document.cookie = `user_name=${userName}; point=''`;
+    window.location.href = '/session.html';
     return false;
   }
 }
 
-$(() => new Join);
+$(() => new Join());

--- a/scripts/session.js
+++ b/scripts/session.js
@@ -4,55 +4,54 @@ import DEFAULT_POINTS from '../configs/defaultPoints';
 
 class Session {
   constructor() {
-    this._checkPermissions();
-    this._initConncetion();
-    this._registerEventHanlders();
-    this._initPointLabels();
+    this.checkPermissions();
+    this.initConncetion();
+    this.registerEventHanlders();
+    this.initPointLabels();
   }
 
-  _checkPermissions() {
+  checkPermissions() {
     this.sessionName = Cookies.get('session_name');
     this.userName = Cookies.get('user_name');
     this.cookiePoint = Cookies.get('point');
 
     // redirect to login page
     if (!this.sessionName) {
-      location.href = '/index.html';
+      window.location.href = '/index.html';
     }
 
     if (this.sessionName && !this.userName) {
-      location.href = '/join_session.html';
+      window.location.href = '/join_session.html';
     }
   }
 
-  _initConncetion() {
+  initConncetion() {
     let ws = new WebSocket('ws://achex.ca:4010');
-    let that = this;
 
-    ws.onmessage = function(evt) {
-      let myReceivedMessage = JSON.parse(evt.data);
+    ws.onmessage = (event) => {
+      let myReceivedMessage = JSON.parse(event.data);
 
       // add new user also sync me to him
       if (myReceivedMessage.type === 'new_connection') {
-        that._appendUser(myReceivedMessage.user_name, myReceivedMessage.point);
-        if (that.userName !== myReceivedMessage.user_name) {
+        this.appendUser(myReceivedMessage.user_name, myReceivedMessage.point);
+        if (this.userName !== myReceivedMessage.user_name) {
           ws.send(JSON.stringify({
             to: myReceivedMessage.user_name,
             type: 'new_connection_sync',
-            user_name: that.userName,
-            point: that.cookiePoint
+            user_name: this.userName,
+            point: this.cookiePoint
           }));
         }
       }
 
       // add sync user
       if (myReceivedMessage.type === 'new_connection_sync') {
-        that._appendUser(myReceivedMessage.user_name, myReceivedMessage.point);
+        this.appendUser(myReceivedMessage.user_name, myReceivedMessage.point);
       }
 
       // sync user update
       if (myReceivedMessage.type === 'user_choose_point') {
-        if (that.userName !== myReceivedMessage.user_name) {
+        if (this.userName !== myReceivedMessage.user_name) {
           let $user = $(`#${myReceivedMessage.user_name}`);
           $user.text(myReceivedMessage.point);
           $user.attr('class', 'ready-point');
@@ -61,9 +60,9 @@ class Session {
 
       // clear all votes
       if (myReceivedMessage.type === 'clear_all_votes') {
-        $('td[id]').each(function() {
-          this.innerText = '';
-          this.className = 'hidden-point';
+        $('td[id]').each((index, element) => {
+          element.innerText = '';
+          element.className = 'hidden-point';
         });
 
         Cookies.remove('point');
@@ -71,107 +70,101 @@ class Session {
 
       // show all votes
       if (myReceivedMessage.type === 'show_all_votes') {
-        $('td[id]').each(function() {
-          this.className = '';
+        $('td[id]').each((index, element) => {
+          element.className = '';
         });
       }
     };
 
     // reconnect when server is disconnected
-    ws.onclose = function(evt) {
-      location.reload();
-    };
+    ws.onclose = () => window.location.reload();
 
     // add event handler for error
-    ws.onerror = function(evt) {
-      alert('Server Error');
-    };
+    ws.onerror = () => alert('Server Error');
 
     // add event handler for new connection
-    ws.onopen = function(evt) {
+    ws.onopen = () => {
       // setup user ID
       ws.send(JSON.stringify({
-        setID: that.userName,
+        setID: this.userName,
         passwd: 'free'
       }));
 
       // register Broadcast
       ws.send(JSON.stringify({
         cmd: 'register_broadcast',
-        bid: that.sessionName
+        bid: this.sessionName
       }));
 
       // broadcast new connection
       ws.send(JSON.stringify({
-        bc: that.sessionName,
-        type:'new_connection',
-        user_name: that.userName,
-        point: that.cookiePoint
+        bc: this.sessionName,
+        type: 'new_connection',
+        user_name: this.userName,
+        point: this.cookiePoint
       }));
     };
 
     this.ws = ws;
   }
 
-  _registerEventHanlders() {
-    let that = this;
-
-    $('#point-labels').on('click', 'button', function() {
-      let point = this.textContent.replace(/[^(\d\.)|?]*/g, '');
-      let $user = $(`#${that.userName}`);
+  registerEventHanlders() {
+    $('#point-labels').on('click', 'button', (event) => {
+      let point = event.target.textContent.replace(/[^(\d)|?]*/g, '');
+      let $user = $(`#${this.userName}`);
 
       $user.text(point);
       $user.attr('class', 'ready-point');
 
       Cookies.set('point', point);
 
-      that.ws.send(JSON.stringify({
-        bc: that.sessionName,
+      this.ws.send(JSON.stringify({
+        bc: this.sessionName,
         type: 'user_choose_point',
-        user_name: that.userName,
+        user_name: this.userName,
         point
       }));
     });
 
     // clear all votes
-    $('#clear-votes').click(function() {
-      $('td[id]').each(function() {
-        this.innerText = '';
-        this.className = 'hidden-point';
+    $('#clear-votes').click(() => {
+      $('td[id]').each((index, element) => {
+        element.innerText = '';
+        element.className = 'hidden-point';
       });
 
       Cookies.remove('point');
 
-      that.ws.send(JSON.stringify({
-        bc: that.sessionName,
+      this.ws.send(JSON.stringify({
+        bc: this.sessionName,
         type: 'clear_all_votes'
       }));
     });
 
     // show votes
-    $('#show-votes').click(function() {
+    $('#show-votes').click(() => {
       // $('td.hidden-point').removeClass('hidden-point');
-      $('td[id]').each(function() {
-        this.className = '';
+      $('td[id]').each((index, element) => {
+        element.className = '';
       });
 
-      that.ws.send(JSON.stringify({
-        bc: that.sessionName,
-        type:'show_all_votes'
+      this.ws.send(JSON.stringify({
+        bc: this.sessionName,
+        type: 'show_all_votes'
       }));
     });
   }
 
-  _initPointLabels() {
+  initPointLabels() {
     $('#session-name').text(this.sessionName);
-    for (let i = 0 ; i < DEFAULT_POINTS.length; i++) {
+    for (let i = 0; i < DEFAULT_POINTS.length; i++) {
       let $row = $('<button type="button" class="btn btn-info points">');
       $row.html(DEFAULT_POINTS[i].label);
       $('#point-labels').append($row);
     }
   }
 
-  _appendUser(userName, point) {
+  appendUser(userName, point) {
     if ($(`td[id=${userName}]`)[0] === undefined) {
       let $userPointList = $('#user-point-list');
       if (point === undefined || point === 'undefined') {
@@ -183,4 +176,4 @@ class Session {
   }
 }
 
-$(() => new Session);
+$(() => new Session());

--- a/scripts/session_new.js
+++ b/scripts/session_new.js
@@ -3,11 +3,11 @@ import DEFAULT_POINTS from '../configs/defaultPoints';
 
 class NewSession {
   constructor() {
-    this._initDefaultPoints();
-    this._initEventHandlers();
+    this.initDefaultPoints();
+    this.initEventHandlers();
   }
 
-  _initDefaultPoints() {
+  initDefaultPoints() {
     for (let i = 0; i < DEFAULT_POINTS.length; i++) {
       let row$ = $('<tr>');
       let label = DEFAULT_POINTS[i].label;
@@ -18,29 +18,31 @@ class NewSession {
     }
   }
 
-  _initEventHandlers() {
-    $('#btn-create-session').click(function() {
-      let sessionName = $('#input-session-name').val();
+  initEventHandlers() {
+    $('#btn-create-session').click(this.handleCreateSession);
+  }
 
-      $.ajax('https://leancloud.cn:443/1.1/classes/session', {
-        method: 'POST',
-        headers: {
-          'X-LC-Id': 'IuBpRcjICs1OlVjLeBm99rSO-gzGzoHsz',
-          'X-LC-Key': 'Tan5kGI0Swx4cMte10sHrEjW'
-        },
-        contentType: 'application/json',
-        processData: false,
-        data: JSON.stringify({
-          name: sessionName,
-          points: DEFAULT_POINTS
-        }),
-        success: function(data) {
-          document.cookie = `session_name=${sessionName}`;
-          location.href = '/join_session.html';
-        }
-      });
+  handleCreateSession() {
+    let sessionName = $('#input-session-name').val();
+
+    $.ajax('https://leancloud.cn:443/1.1/classes/session', {
+      method: 'POST',
+      headers: {
+        'X-LC-Id': 'IuBpRcjICs1OlVjLeBm99rSO-gzGzoHsz',
+        'X-LC-Key': 'Tan5kGI0Swx4cMte10sHrEjW'
+      },
+      contentType: 'application/json',
+      processData: false,
+      data: JSON.stringify({
+        name: sessionName,
+        points: DEFAULT_POINTS
+      }),
+      success() {
+        window.document.cookie = `session_name=${sessionName}`;
+        window.location.href = '/join_session.html';
+      }
     });
   }
 }
 
-$(() => new NewSession);
+$(() => new NewSession());


### PR DESCRIPTION
This PR does

- Introduce ESLint into npm scripts and travis ci process (use Airbnb JavaScript style)
- Update warnings and errors according to lint results
- Add some customized ESLint rules
- Remove `let that = this`. In #13 , I added `that` in our code, since when ES6 was introduced, I used `class`, and I saved some common values with `this` (it's current class).
However, in our code, we always used `this` in jQuery selector to indicate current element. That said, there are conflicts between two `this`s. Hence `that` I added.
In this PR, I found for the latter case, we can use `event.target` in `$('#point-labels').on('click', 'button', (event) => {}` and `element` in `$('td[id]').each((index, element) => {}` to indicate current element instead of using `this`. In this case, we can safely change all the `function()` to arrow function.

BTW, if you think some of Airbnb JavaScript rules are not acceptable, please rewrite them in `.eslintrc.json` under `rules` node.