### PR TITLE
Implement optimistic update

### DIFF
--- a/src/components/Actions/Actions.js
+++ b/src/components/Actions/Actions.js
@@ -13,7 +13,7 @@ class Actions extends Component {
   }
 
   render() {
-    const { show, score, onVote, onToggleShow, onClear } = this.props;
+    const { show, score, onVote, onShow, onClear } = this.props;
     const listItems = validScores.map((item) => {
       const buttonClass = classNames({ 'selected': this.checkSelectedValue(item, score) });
       return (
@@ -32,7 +32,7 @@ class Actions extends Component {
           {show ? (
             <li><button onClick={onClear} className="danger">Clear</button></li>
           ) : (
-            <li><button onClick={onToggleShow}>Show</button></li>
+            <li><button onClick={onShow}>Show</button></li>
           )}
         </ul>
       </div>

--- a/src/pages/Room/Room.js
+++ b/src/pages/Room/Room.js
@@ -43,18 +43,40 @@ class Room extends Component {
 
   handlePlayerJoin = (name) => {
     Cookies.set('playerName', name);
+    this.setState({
+      me: {
+        id: this.socketId,
+        name,
+        score: null,
+        voted: false
+      }
+    });
     this.socket.emit('play', name);
   };
 
   handleVote = (e) => {
-    this.socket.emit('vote', e.target.value);
+    const score = e.target.value;
+    this.setState(prevState => ({
+      me: Object.assign({}, prevState.me, { score, voted: true })
+    }));
+    this.socket.emit('vote', score);
   };
 
-  handleToggleShow = () => {
+  handleShow = () => {
+    this.setState(prevState => ({
+      show: true
+    }));
     this.socket.emit('show', true);
   };
 
   handleClear= () => {
+    this.setState(prevState => ({
+      me: Object.assign({}, prevState.me, { score: null, voted: false }),
+      team: prevState.team.map(player => (
+        Object.assign({}, player, { score: null, voted: false })
+      )),
+      show: false
+    }));
     this.socket.emit('clear');
   };
 
@@ -67,7 +89,7 @@ class Room extends Component {
             show={show}
             score={me.score}
             onVote={this.handleVote}
-            onToggleShow={this.handleToggleShow}
+            onShow={this.handleShow}
             onClear={this.handleClear}/>
         ) : (
           <Join


### PR DESCRIPTION
This solves #23.

I have tested this and I think it's more robust than I expected. On the other hand, things could look a bit weird if the connection is _really_ slow and multiple players clicked the show / clear button simultaneously or one of the players cleared the table before the other players vote. That being said, these problems are there even when there's no optimistic update.

After all, we could use a better server. 😉