### PR TITLE
Sort participant names properly

### DIFF
--- a/src/components/Votes/Votes.js
+++ b/src/components/Votes/Votes.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Card from 'components/Card/Card';
 import './Votes.css';
 
-const collator = Intl && 'Collator' in Intl
+const collator = Intl && ('Collator' in Intl)
   ? new Intl.Collator()
   : { compare: (a, b) => a.localeCompare(b) };
 

--- a/src/components/Votes/Votes.js
+++ b/src/components/Votes/Votes.js
@@ -2,12 +2,22 @@ import React, { Component } from 'react';
 import Card from 'components/Card/Card';
 import './Votes.css';
 
-class Votes extends Component {
+const collator = (() => {
+  if (Intl && 'Collator' in Intl) {
+    return new Intl.Collator();
+  } else {
+    return {
+      compare: (a, b) => a.localeCompare(b)
+    };
+  }
+})();
+
+class Votes extends Component { 
   render() {
     const { me, myScore, team, show } = this.props;
     const listItems = team
-      .slice() // shallow copy to prevent sort from mutating the state directly
-      .sort((a, b) => (a.name > b.name ? 1 : -1))
+      .slice() // shallow copy to avoid mutating the state directly
+      .sort((a, b) => collator.compare(a.name, b.name))
       .map((member) =>
         <li key={member.id}>
           <dd>

--- a/src/components/Votes/Votes.js
+++ b/src/components/Votes/Votes.js
@@ -2,15 +2,9 @@ import React, { Component } from 'react';
 import Card from 'components/Card/Card';
 import './Votes.css';
 
-const collator = (() => {
-  if (Intl && 'Collator' in Intl) {
-    return new Intl.Collator();
-  } else {
-    return {
-      compare: (a, b) => a.localeCompare(b)
-    };
-  }
-})();
+const collator = Intl && 'Collator' in Intl
+  ? new Intl.Collator()
+  : { compare: (a, b) => a.localeCompare(b) };
 
 class Votes extends Component { 
   render() {


### PR DESCRIPTION
This resolves #38.

[Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) is introduced as the best practice of sorting people's names, which is based on language sensitive string comparison.

[Browser support](http://caniuse.com/#feat=internationalization) is quite good at this point, a fallback to `string.localeCompare` is there anyway, in case it's not supported, like on Safari 9.