### PR TITLE
Fix Client-Side Routing on Surge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ script:
   - yarn test
   - yarn build
 
+# https://surge.sh/help/adding-a-200-page-for-client-side-routing
+before_deploy:
+  - cp ./build/index.html ./build/200.html
+
 deploy:
   - provider: surge
     project: ./build/


### PR DESCRIPTION
We need a `200.html` for using client-side routing on Surge. This was removed when we migrate to dedicated server and I forgot to add back when I added Surge back as stage environment.