### PR TITLE
Isolate Animation State

### DIFF
--- a/src/components/Votes/Votes.js
+++ b/src/components/Votes/Votes.js
@@ -27,7 +27,7 @@ const Bounce = ({ children, ...props }) => (
 
 class Votes extends Component {
   render() {
-    const { me, myScore, highlightScore, team, show } = this.props;
+    const { me, myScore, highlightScore, team, playerAction, show } = this.props;
     const listItems = team
       .slice() // shallow copy to avoid mutating the state directly
       .sort((a, b) => collator.compare(a.name, b.name))
@@ -35,7 +35,7 @@ class Votes extends Component {
         <Fade key={member.id}>
           <li>
             <dd>
-              <Bounce in={member.voting}>
+              <Bounce in={playerAction[member.id] && playerAction[member.id].voting}>
                 <Card
                   highlight={member.score === highlightScore && highlightScore !== null}
                   score={member.score}
@@ -55,7 +55,7 @@ class Votes extends Component {
             <Fade key={me.id}>
               <li>
                 <dd>
-                  <Bounce in={me.voting}>
+                  <Bounce in={playerAction[me.id] && playerAction[me.id].voting}>
                     <Card
                       highlight={myScore === highlightScore && highlightScore !== null}
                       score={myScore}

--- a/src/components/Votes/Votes.test.js
+++ b/src/components/Votes/Votes.test.js
@@ -6,6 +6,7 @@ describe('<Votes />', () => {
   describe('Structures', () => {
     let me;
     let team;
+    let playerAction;
 
     beforeEach(() => {
       me = {
@@ -40,24 +41,25 @@ describe('<Votes />', () => {
           voted: false
         }
       ];
+      playerAction = {};
     });
 
     it('should render without crashing', () => {
-      shallow(<Votes team={team} />);
+      shallow(<Votes team={team} playerAction={playerAction} />);
     });
 
     it('should render correct number of cards', () => {
-      const wrapper = shallow(<Votes me={me} team={team} show={true} />);
+      const wrapper = shallow(<Votes me={me} team={team} playerAction={playerAction} show={true} />);
       expect(wrapper.find('Card')).toHaveLength(5);
     });
 
     it('should render `me` as the first card', () => {
-      const wrapper = shallow(<Votes me={me} team={team} show={true} />);
+      const wrapper = shallow(<Votes me={me} team={team} playerAction={playerAction} show={true} />);
       expect(wrapper.find('.Votes li').at(0).find('dt').text()).toEqual('just4fun');
     });
 
     it('should sort other player names alphabetically', () => {
-      const wrapper = shallow(<Votes me={me} team={team} show={true} />);
+      const wrapper = shallow(<Votes me={me} team={team} playerAction={playerAction} show={true} />);
       expect(wrapper.find('.Votes li').at(1).find('dt').text()).toEqual('frank');
       expect(wrapper.find('.Votes li').at(2).find('dt').text()).toEqual('hiveer');
       expect(wrapper.find('.Votes li').at(3).find('dt').text()).toEqual('hyjk2000');

--- a/src/lib/player-state-pinger.js
+++ b/src/lib/player-state-pinger.js
@@ -16,10 +16,10 @@ class PlayerStatePinger {
 
   setPlayerState(playerId, state, value) {
     this.setState(prevState => {
-      const nextState = Object.assign({}, prevState);
-      const { me, team } = nextState;
-      const player = [me, ...team].find(client => client && client.id === playerId);
-      player[state] = value;
+      const nextState = { ...prevState };
+      if (nextState.playerAction[playerId] === undefined)
+        nextState.playerAction[playerId] = {};
+      nextState.playerAction[playerId][state] = value;
       return nextState;
     });
   }

--- a/src/lib/player-state-pinger.js
+++ b/src/lib/player-state-pinger.js
@@ -16,7 +16,7 @@ class PlayerStatePinger {
 
   setPlayerState(playerId, state, value) {
     this.setState(prevState => {
-      const nextState = { ...prevState };
+      const nextState = { ...prevState, playerAction: { ...prevState.playerAction } };
       if (nextState.playerAction[playerId] === undefined)
         nextState.playerAction[playerId] = {};
       nextState.playerAction[playerId][state] = value;

--- a/src/lib/player-state-pinger.js
+++ b/src/lib/player-state-pinger.js
@@ -15,13 +15,15 @@ class PlayerStatePinger {
   }
 
   setPlayerState(playerId, state, value) {
-    this.setState(prevState => {
-      const nextState = { ...prevState, playerAction: { ...prevState.playerAction } };
-      if (nextState.playerAction[playerId] === undefined)
-        nextState.playerAction[playerId] = {};
-      nextState.playerAction[playerId][state] = value;
-      return nextState;
-    });
+    this.setState(prevState => ({
+      ...prevState,
+      playerAction: {
+        ...prevState.playerAction,
+        [playerId]: {
+          [state]: value
+        }
+      }
+    }));
   }
 
   clearTimeouts(timeouts = this.timeouts) {

--- a/src/lib/player-state-pinger.test.js
+++ b/src/lib/player-state-pinger.test.js
@@ -9,7 +9,8 @@ describe('lib/player-state-pinger', () => {
         {
           id: '9527'
         }
-      ]
+      ],
+      playerAction: {}
     };
     let nextState = null;
     let instance = new PlayerStatePinger({
@@ -20,6 +21,6 @@ describe('lib/player-state-pinger', () => {
       }
     });
     instance.setPlayerState('9527', 'voting', true);
-    expect(nextState.team.find(player => player.id === '9527').voting).toEqual(true);
+    expect(nextState.playerAction['9527'].voting).toEqual(true);
   });
 });

--- a/src/pages/Room/Room.js
+++ b/src/pages/Room/Room.js
@@ -17,6 +17,7 @@ class Room extends Component {
       myScore: null,
       highlightScore: null,
       team: [],
+      playerAction: {},
       show: false,
       disconnected: false,
       reconnCountdown: 0
@@ -139,7 +140,7 @@ class Room extends Component {
   };
 
   render() {
-    const { me, myScore, highlightScore, team, show, disconnected, reconnCountdown } = this.state;
+    const { me, myScore, highlightScore, team, playerAction, show, disconnected, reconnCountdown } = this.state;
     const playerName = localStorage.getItem('playerName') || '';
     return (
       <div className="Room">
@@ -166,6 +167,7 @@ class Room extends Component {
           myScore={myScore}
           highlightScore={highlightScore}
           team={team}
+          playerAction={playerAction}
           show={show} />
         <Summary
           me={me}


### PR DESCRIPTION
This resolves #58.

By isolating imperative animation states we can protect them from being overwritten by `stateUpdate` event from the server.