### PR TITLE
Validation for room name and player name

### DIFF
--- a/src/components/Join/Join.js
+++ b/src/components/Join/Join.js
@@ -17,6 +17,14 @@ class Join extends Component {
 
   handleSubmit = (e) => { // eslint-disable-line
     e.preventDefault();
+    // The player name could be started with whitespaces, but it's invalid
+    // if there are only whitespaces.
+    if (!this.state.myName.trim()) {
+      this.setState({
+        myName: ''
+      });
+      return;
+    }
     this.props.onSubmit(this.state.myName);
   };
 

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -21,6 +21,14 @@ class Landing extends Component {
   handleSubmit = (e) => { // eslint-disable-line
     e.preventDefault();
     const roomName = this.state.roomName || this.state.randomRoomName;
+    // The room name could be started with whitespaces, but it's invalid
+    // if there are only whitespaces.
+    if (!roomName.trim()) {
+      this.setState({
+        roomName: ''
+      });
+      return;
+    }
     this.props.history.push(roomName);
   };
 

--- a/src/pages/Room/Room.js
+++ b/src/pages/Room/Room.js
@@ -23,8 +23,6 @@ class Room extends Component {
       disconnected: false,
       reconnCountdown: 0
     };
-    // put this line in `constructor` instead of `componentDidMount`
-    // to avoid `undefined` room link in first render.
     this.room = this.props.match.params.room;
     this.playing = false;
     this.playerStatePinger = new PlayerStatePinger({ setState: this.setState.bind(this) });
@@ -32,6 +30,12 @@ class Room extends Component {
 
   componentDidMount() {
     this.socket = io(process.env.REACT_APP_SOCKET_SERVER_URL);
+
+    // Avoid to type `%20` as room name in address bar.
+    if (!this.room.trim()) {
+      this.props.history.push('/');
+      return;
+    }
 
     this.socket.on('stateUpdate', (response, isClearAction) => {
       const me = response.team.find(client => client.id === this.socket.id);


### PR DESCRIPTION
This PR does,

- Avoid room name to be whitespaces only in UI (whitespaces as part of name is accepted)
- Avoid player name to be whitespaces only in UI (whitespaces as part of name is accepted)
- Avoid room name to be whitespaces only with `%20` typed in address bar (whitespaces as part of name is accepted)

In addition, if you type room name directly in address bar,

- Whitespaces only will be ignored and redirect to landing page automatically (expected)
- Whitespaces as prefix will be reserved (accepted)
- Whitespaces as suffix will be ignored (accepted)
- `%20` will not be ignored by browser (not expected), so check it and redirect to landing page manually

