### PR TITLE
Properly position notification for mobile

### DIFF
--- a/src/components/Notification/Notification.css
+++ b/src/components/Notification/Notification.css
@@ -32,6 +32,7 @@
 @media (max-width: 500px) {
   .Notification {
     position: fixed;
+    top: auto;
     bottom: 0;
 
     .countdown {


### PR DESCRIPTION
Just noticed that the offline notification was not properly positioned on mobile. The `top` property should be overwritten for mobile in media query.