### PR TITLE
Responsive Dark Mode

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -25,16 +25,16 @@
     background-color: white;
     box-shadow: 0 0.1em 0.1em rgba(0, 0, 0, 0.2);
     border-radius: calc(var(--card-height) / 10);
-    color: DarkSlateGrey;
+    color: DarkSlateGray;
   }
 
   .back.face {
-    color: LightSlateGrey;
-    background-image: linear-gradient(130deg, LightSlateGrey, DarkSlateGrey);
+    color: LightSteelBlue;
+    background-image: linear-gradient(130deg, LightSteelBlue, SteelBlue);
   }
 
   .front.face {
-    background-image: linear-gradient(130deg, white, LightGrey);
+    background-image: linear-gradient(130deg, white, LightGray);
     transform: rotateY(180deg);
   }
 

--- a/src/components/Join/Join.css
+++ b/src/components/Join/Join.css
@@ -38,7 +38,10 @@
     width: 9em;
     margin: 0 0.5rem;
     border: none;
-    border-bottom: 2px solid black;
+    border-bottom: 2px solid;
+    border-bottom-color: inherit;
+    background: transparent;
+    color: inherit;
     text-align: center;
     font-family: inherit;
     font-size: inherit;

--- a/src/components/Share/Share.css
+++ b/src/components/Share/Share.css
@@ -11,6 +11,10 @@
     strong {
       font-weight: 600;
     }
+
+    @media screen and (prefers-color-scheme: dark) {
+      color: rgb(254, 255, 254);
+    }
   }
 
   input {
@@ -19,7 +23,8 @@
   }
 
   a {
-    border-bottom: 2px solid black;
+    border-bottom: 2px solid;
+    border-bottom-color: inherit;
     color: inherit;
     text-decoration: none;
   }
@@ -51,6 +56,17 @@
       font-size: x-small;
       color: white;
       white-space: nowrap;
+    }
+  }
+
+  @media screen and (prefers-color-scheme: dark) {
+    [aria-label]:hover:before {
+      background: rgb(215, 215, 216);
+    }
+
+    [aria-label]:hover:after {
+      background: rgb(215, 215, 216);
+      color: black;
     }
   }
 }

--- a/src/components/Summary/Summary.css
+++ b/src/components/Summary/Summary.css
@@ -33,7 +33,7 @@
   dt {
     margin-top: -1.5em;
     white-space: nowrap;
-    color: DarkSlateGrey;
+    color: DarkSlateGray;
 
     small {
       display: block;
@@ -48,7 +48,7 @@
     width: var(--summary-item-width);
     height: var(--summary-item-height);
     margin: 0;
-    color: DarkSlateGrey;
+    color: DarkSlateGray;
     background-image: linear-gradient(to bottom, #1cd8d2, #93edc7);
     border-radius: calc(var(--summary-item-height) / 10);
     overflow: hidden;

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,11 @@ body,
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
+
+  @media screen and (prefers-color-scheme: dark) {
+    background-color: rgb(22, 23, 22);
+    color: rgb(215, 215, 216);
+  }
 }
 
 @media screen and (max-width: 500px) {

--- a/src/pages/Landing/Landing.css
+++ b/src/pages/Landing/Landing.css
@@ -8,12 +8,21 @@
   background-size: cover;
   /* background-position: center; */
 
+  @media screen and (prefers-color-scheme: dark) {
+    background-blend-mode: multiply;
+    background-color: DimGray;
+  }
+
   .Form {
     grid-row-start: 2;
     padding: 1rem;
     background: rgba(255, 255, 255, 0.7);
     backdrop-filter: saturate(180%) blur(20px);
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+
+    @media screen and (prefers-color-scheme: dark) {
+      background: rgba(0, 0, 0, 0.7);
+    }
   }
 
   h1 {
@@ -22,6 +31,10 @@
 
     strong {
       font-weight: 600;
+    }
+
+    @media screen and (prefers-color-scheme: dark) {
+      color: rgb(254, 255, 254);
     }
   }
 
@@ -57,8 +70,10 @@
     width: 200px;
     margin-left: 0.5rem;
     border: none;
-    border-bottom: 2px solid black;
+    border-bottom: 2px solid;
+    border-bottom-color: inherit;
     background: transparent;
+    color: inherit;
     text-align: center;
     font-family: inherit;
     font-size: inherit;


### PR DESCRIPTION
![poker4fun-dark-mode-1](https://user-images.githubusercontent.com/4647136/51920432-58dde000-2420-11e9-94f9-4ffda78958ee.gif)

![poker4fun-dark-mode-2](https://user-images.githubusercontent.com/4647136/51920513-875bbb00-2420-11e9-8568-daedf6ab3b30.gif)

The new Dark Mode™ that respond to dark mode preference provided by operating systems.

[Dark Mode CSS Support](https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme) will be available first on [Safari](https://bugs.webkit.org/show_bug.cgi?id=190499) with macOS 10.14.4. Support on [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=889087) and [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1494034) are underway.

Currently the only way to test this is with [Safari Technology Preview](https://developer.apple.com/safari/technology-preview/) on macOS Mojave. Judging from the discussions in the aforementioned Chrome bug, it probably will be supported on Windows 10 at some point.

The new design is preliminary and open for discussion. Apple Human Interface Guidelines has an [article](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/) on the concept and principles of dark mode design.